### PR TITLE
Update index.md

### DIFF
--- a/zh/advanced-topics/jsb/swig/tutorial/index.md
+++ b/zh/advanced-topics/jsb/swig/tutorial/index.md
@@ -137,7 +137,7 @@ module.exports = {
 
 ```bash
 cd /Users/james/NewProject/tools/swig-config
-node < 引擎根目录 >/native/tools/swig-config/genbindings.js
+node < 引擎根目录 >/native/tools/swig-config/genbindings.js -c swig-config.js
 ```
 
 如果成功，包含自动绑定代码的 `jsb_my_module_auto.cpp/.h` 两个文件将被创建到 `/Users/james/NewProject/native/engine/bindings/auto` 目录下。


### PR DESCRIPTION

![image](https://github.com/cocos/cocos-docs/assets/42135824/083db9c8-5525-43b8-b765-f5b9c5d07375)

缺少参数-c swig-config.js执行会报
The engine's binding code is now automatically generated by CMake, eliminating the need to run the script manually. Notice: if any ".i" configuration files are added or removed, please re-generate the project to ensure the changes are applied. 的错误。