### PR TITLE
Fix button en typo

### DIFF
--- a/versions/3.0/en/ui-system/components/editor/button.md
+++ b/versions/3.0/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.1/en/ui-system/components/editor/button.md
+++ b/versions/3.1/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.2/en/ui-system/components/editor/button.md
+++ b/versions/3.2/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.3/en/ui-system/components/editor/button.md
+++ b/versions/3.3/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.4/en/ui-system/components/editor/button.md
+++ b/versions/3.4/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.5/en/ui-system/components/editor/button.md
+++ b/versions/3.5/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.6/en/ui-system/components/editor/button.md
+++ b/versions/3.6/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.7/en/ui-system/components/editor/button.md
+++ b/versions/3.7/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {

--- a/versions/3.8/en/ui-system/components/editor/button.md
+++ b/versions/3.8/en/ui-system/components/editor/button.md
@@ -114,7 +114,7 @@ There are two ways to add a callback through the script.
     const { ccclass, property } = _decorator;
 
     @ccclass("example")
-    export class example ex tends Component {
+    export class example extends Component {
         @property(Button)
         button: Button | null = null;
         onLoad () {


### PR DESCRIPTION
Found small typo in button across **3.x** docs.

before
```ts
@ccclass("example")
export class example ex tends Component {
    @property(Button)
    button: Button | null = null;
    onLoad () {
        this.button.node.on(Button.EventType.CLICK, this.callback, this);
    }
```

after
```ts
@ccclass("example")
export class example extends Component {
    @property(Button)
    button: Button | null = null;
    onLoad () {
        this.button.node.on(Button.EventType.CLICK, this.callback, this);
    }
```